### PR TITLE
refactor: move animations from JS to CSS

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,29 +1,43 @@
 body {
   margin: 0;
   font-family: "Comic Neue", cursive;
-}
-
-.wrapper {
   height: 100vh;
-  width: 100%;
-  background-color: black;
-}
-
-header {
-  font-size: 4em;
-  text-align: center;
-}
-
-p {
-  font-size: 0.5em;
-}
-
-.center {
-  margin: 0 auto;
-  height: 100%;
+  width: 100vw;
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   flex-direction: column;
+  background-color: black;
   color: white;
-}/*# sourceMappingURL=main.css.map */
+}
+
+.fade-up {
+  animation: fade-up 500ms cubic-bezier(0, 0.55, 0.45, 1);
+  animation-fill-mode: backwards;
+}
+.fade-up.delay-500 {
+  animation-delay: 500ms;
+}
+@keyframes fade-up {
+  from {
+    transform: translateY(200%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+h1 {
+  font-size: 4em;
+  font-weight: 300;
+  margin: 0;
+}
+
+h2 {
+  font-size: 2em;
+  font-weight: 300;
+}
+
+/*# sourceMappingURL=main.css.map */

--- a/css/main.css.map
+++ b/css/main.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["main.scss","main.css"],"names":[],"mappings":"AAAA;EACI,SAAA;EACA,kCAAA;ACCJ;;ADEA;EACI,aAAA;EACA,WAAA;EACA,uBAAA;ACCJ;;ADGA;EACI,cAAA;EACA,kBAAA;ACAJ;;ADGA;EACI,gBAAA;ACAJ;;ADGA;EACI,cAAA;EACA,YAAA;EACA,aAAA;EACA,uBAAA;EACA,mBAAA;EACA,sBAAA;EACA,YAAA;ACAJ","file":"main.css"}
+{"version":3,"sourceRoot":"","sources":["main.scss"],"names":[],"mappings":"AAAA;EACI;EACA;EACA;EACA;EAEA;EACA;EACA;EACA;EACA;EACA;;;AAGJ;EACI;EACA;;AAEA;EACI;;AAGJ;EACI;IACI;IACA;;EAEJ;IACI;IACA;;;;AAKZ;EACI;EACA;EACA;;;AAGJ;EACI;EACA","file":"main.css"}

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,30 +1,46 @@
 body {
     margin: 0;
     font-family: 'Comic Neue', cursive;
-}
-
-.wrapper {
     height: 100vh;
-    width: 100%;
-    background-color: black;
+    width: 100vw;
 
-}
-
-header {
-    font-size: 4em;
-    text-align: center;
-}
-
-p{
-    font-size: 0.5em;
-    
-}
-.center {
-    margin: 0 auto;
-    height: 100%;
     display: flex;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
     flex-direction: column;
+    background-color: black;
     color: white;
 }
+
+.fade-up {
+    animation: fade-up 500ms cubic-bezier(0, 0.55, 0.45, 1);
+    animation-fill-mode: backwards;
+    
+    &.delay-500 {
+        animation-delay: 500ms;
+    }
+    
+    @keyframes fade-up {
+        from {
+            transform: translateY(200%);
+            opacity: 0;
+        }
+        to {
+            transform: translateY(0);
+            opacity: 1;
+        }
+    }
+}
+
+h1 {
+    font-size: 4em;
+    font-weight: 300;
+    margin: 0;
+}
+
+h2 {
+    font-size: 2em;
+    font-weight: 300;
+}
+
+

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/css/main.css">
-    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -22,17 +21,8 @@
 </head>
 
 <body>
-
-    <div class="wrapper">
-        <header class="center" data-aos="fade-up">group "GROUP" project team
-            <p data-aos="fade-up" data-aos-delay="500">coming soon</p>
-        </header>
-    </div>
-
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <script>
-        AOS.init();
-    </script>
+        <h1 class="fade-up">group "GROUP" project team</h1>
+        <h2 class="fade-up delay-500">coming soon</h2>
 </body>
 
 </html>


### PR DESCRIPTION
The fade animations can use CSS instead of Javascript. This removes the dependency on aos.